### PR TITLE
Do not call aarch64 assembly for 12-bit inverse transforms

### DIFF
--- a/src/asm/aarch64/transform/inverse.rs
+++ b/src/asm/aarch64/transform/inverse.rs
@@ -25,7 +25,7 @@ pub fn inverse_transform_add<T: Pixel>(
       if let Some(func) = INV_TXFM_FNS[cpu.as_index()]
         [get_tx_size_idx(tx_size)][get_tx_type_idx(tx_type)]
       {
-        return call_inverse_func(
+        call_inverse_func(
           func,
           input,
           output,
@@ -36,24 +36,25 @@ pub fn inverse_transform_add<T: Pixel>(
         );
       }
     }
-    PixelType::U16 => {
+    PixelType::U16 if bd == 10 => {
       if let Some(func) = INV_TXFM_HBD_FNS[cpu.as_index()]
         [get_tx_size_idx(tx_size)][get_tx_type_idx(tx_type)]
       {
-        return call_inverse_hbd_func(
+        call_inverse_hbd_func(
           func,
           input,
           output,
           eob,
           tx_size.width(),
           tx_size.height(),
-          (1 << bd) - 1,
+          bd,
         );
       }
     }
+    _ => rust::inverse_transform_add(
+      input, output, eob, tx_size, tx_type, bd, cpu,
+    ),
   };
-
-  rust::inverse_transform_add(input, output, eob, tx_size, tx_type, bd, cpu);
 }
 
 macro_rules! decl_itx_fns {

--- a/src/asm/shared/transform/inverse.rs
+++ b/src/asm/shared/transform/inverse.rs
@@ -38,7 +38,7 @@ pub fn call_inverse_func<T: Pixel>(
   unsafe {
     func(
       output.data_ptr_mut() as *mut _,
-      output.plane_cfg.stride as isize,
+      T::to_asm_stride(output.plane_cfg.stride) as isize,
       copied.data.as_mut_ptr() as *mut _,
       eob as i32,
     );
@@ -67,7 +67,7 @@ pub fn call_inverse_hbd_func<T: Pixel>(
   unsafe {
     func(
       output.data_ptr_mut() as *mut _,
-      output.plane_cfg.stride as isize,
+      T::to_asm_stride(output.plane_cfg.stride) as isize,
       copied.data.as_mut_ptr() as *mut _,
       eob as i32,
     );


### PR DESCRIPTION
See https://code.videolan.org/videolan/dav1d/-/blob/0.7.1/src/arm/itx_init_tmpl.c#L120
Also, `T::to_asm_stride()` strikes again.